### PR TITLE
Let Them Fight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .ruff_cache
 .mypy_cache
 __pycache__
+.coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.13.0"  # Also update in pyproject.toml
+    rev: "v1.15.0"  # Also update in pyproject.toml
     hooks:
       - id: mypy
         language_version: "3.12"
@@ -28,7 +28,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.8.3
+    rev: v0.9.10
     hooks:
       - id: ruff
         args:

--- a/src/tmt_web/api.py
+++ b/src/tmt_web/api.py
@@ -289,7 +289,7 @@ def root(
             alias="format",
             description="Output format for the response",
         ),
-    ] = "json",
+    ] = "html",
 ) -> TaskOut | HTMLResponse | JSONResponse | PlainTextResponse | RedirectResponse:
     """Process a request for test, plan, or both.
 
@@ -388,7 +388,7 @@ def get_task_status_html(
     if r.successful() and r.result:
         # For successful tasks, redirect to root endpoint
         return RedirectResponse(
-            url=f"{settings.API_HOSTNAME}/?task-id={r.task_id}&format=html",
+            url=f"{settings.API_HOSTNAME}/?task-id={r.task_id}",
             status_code=303,  # Use 303 See Other for GET redirects
         )
 

--- a/src/tmt_web/templates/testandplan.html.j2
+++ b/src/tmt_web/templates/testandplan.html.j2
@@ -5,10 +5,9 @@
 {% block content %}
 {# Test Section #}
 <section>
-  <h1>Test Information</h1>
+  <h1>{{ test.name }}</h1>
 
   <div class="metadata">
-    <p><strong>Name:</strong> {{ test.name }}</p>
     {% if test.summary %}
     <p><strong>Summary:</strong> {{ test.summary }}</p>
     {% endif %}
@@ -34,9 +33,7 @@
       {% if test.fmf_id.ref %}
       <p><strong>Reference:</strong> {{ test.fmf_id.ref }}</p>
       {% endif %}
-      {% if test.fmf_id.name %}
-      <p><strong>Name:</strong> {{ test.fmf_id.name }}</p>
-      {% endif %}
+      {# fmf_id.name is redundant since it's already in the heading #}
       {% if test.fmf_id.path %}
       <p><strong>Path:</strong> {{ test.fmf_id.path }}</p>
       {% endif %}
@@ -62,10 +59,9 @@
 
 {# Plan Section #}
 <section>
-  <h1>Plan Information</h1>
+  <h1>{{ plan.name }}</h1>
 
   <div class="metadata">
-    <p><strong>Name:</strong> {{ plan.name }}</p>
     {% if plan.summary %}
     <p><strong>Summary:</strong> {{ plan.summary }}</p>
     {% endif %}
@@ -91,9 +87,7 @@
       {% if plan.fmf_id.ref %}
       <p><strong>Reference:</strong> {{ plan.fmf_id.ref }}</p>
       {% endif %}
-      {% if plan.fmf_id.name %}
-      <p><strong>Name:</strong> {{ plan.fmf_id.name }}</p>
-      {% endif %}
+      {# fmf_id.name is redundant since it's already in the heading #}
       {% if plan.fmf_id.path %}
       <p><strong>Path:</strong> {{ plan.fmf_id.path }}</p>
       {% endif %}

--- a/src/tmt_web/templates/testorplan.html.j2
+++ b/src/tmt_web/templates/testorplan.html.j2
@@ -7,7 +7,6 @@
   <h1>{{ testorplan.name }}</h1>
 
   <div class="metadata">
-    <p><strong>Name:</strong> {{ testorplan.name }}</p>
     {% if testorplan.summary %}
     <p><strong>Summary:</strong> {{ testorplan.summary }}</p>
     {% endif %}
@@ -33,9 +32,7 @@
       {% if testorplan.fmf_id.ref %}
       <p><strong>Reference:</strong> {{ testorplan.fmf_id.ref }}</p>
       {% endif %}
-      {% if testorplan.fmf_id.name %}
-      <p><strong>Name:</strong> {{ testorplan.fmf_id.name }}</p>
-      {% endif %}
+      {# fmf_id.name is redundant since it's already in the heading #}
       {% if testorplan.fmf_id.path %}
       <p><strong>Path:</strong> {{ testorplan.fmf_id.path }}</p>
       {% endif %}

--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -60,3 +60,19 @@ def test_convert_field_value_other_field():
     value = "test value"
     result = _convert_field_value("summary", value)
     assert result == value
+
+
+def test_convert_fmf_id_none():
+    """Test converting fmf_id when it doesn't exist."""
+    from unittest.mock import MagicMock
+
+    from tmt_web.converters import _convert_fmf_id
+
+    # Create a mock object without fmf_id attribute
+    mock_obj = MagicMock()
+    # Ensure fmf_id doesn't exist
+    if hasattr(mock_obj, "fmf_id"):
+        delattr(mock_obj, "fmf_id")
+
+    result = _convert_fmf_id(mock_obj)
+    assert result is None

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -1,0 +1,51 @@
+"""Unit tests for the formatters module."""
+
+import json
+
+from tmt_web.formatters import deserialize_data, serialize_data
+from tmt_web.models import TestData, TestPlanData
+
+
+def test_serialize_data_test_data():
+    """Test serializing TestData."""
+    test_data = TestData(
+        name="/tests/core/smoke",
+        summary="Just a basic smoke test",
+        contact=["Petr Šplíchal <psplicha@redhat.com>"],
+        framework="shell",
+        fmf_id={
+            "name": "/tests/core/smoke",
+            "url": "https://github.com/teemtee/tmt/tree/main/tests/core/smoke/main.fmf",
+            "path": None,
+            "ref": "main",
+        },
+    )
+
+    # Test serialization
+    serialized = serialize_data(test_data)
+    assert isinstance(serialized, str)
+
+    # Verify it's valid JSON
+    parsed = json.loads(serialized)
+    assert parsed["name"] == "/tests/core/smoke"
+    assert "fmf-id" in parsed  # Check for hyphenated field name in the output
+
+
+def test_deserialize_data_test_plan_data():
+    """Test deserializing to TestPlanData."""
+    serialized = json.dumps(
+        {
+            "test": {
+                "name": "/tests/core/smoke",
+                "summary": "Just a basic smoke test",
+                "framework": "shell",
+            },
+            "plan": {"name": "/plans/basic", "summary": "Basic plan"},
+        }
+    )
+
+    # Should detect it's a TestPlanData
+    result = deserialize_data(serialized)
+    assert isinstance(result, TestPlanData)
+    assert result.test.name == "/tests/core/smoke"
+    assert result.plan.name == "/plans/basic"

--- a/tests/unit/test_html_generator.py
+++ b/tests/unit/test_html_generator.py
@@ -88,7 +88,12 @@ class TestHtmlGenerator:
 
         # Check content
         assert f"<h1>{test_data.name}</h1>" in data
-        assert f"<p><strong>Name:</strong> {test_data.name}</p>" in data
+
+        # Name should not be shown as metadata since it's now the heading
+        assert f"<p><strong>Name:</strong> {test_data.name}</p>" not in data
+
+        # Also make sure fmf_id.name is not displayed
+        assert f"<p><strong>Name:</strong> {test_data.fmf_id.name}</p>" not in data
         assert test_data.summary in data
 
     def test_generate_testplan_html(self, test_data, plan_data, logger):
@@ -101,14 +106,20 @@ class TestHtmlGenerator:
         assert "Test and Plan Information" in data
 
         # Check test content
-        assert "Test Information" in data
-        assert f"<p><strong>Name:</strong> {test_data.name}</p>" in data
+        assert f"<h1>{test_data.name}</h1>" in data
+        assert f"<p><strong>Name:</strong> {test_data.name}</p>" not in data
+
+        # Also make sure fmf_id.name is not displayed
+        assert f"<p><strong>Name:</strong> {test_data.fmf_id.name}</p>" not in data
         assert test_data.summary in data
 
         # Check plan content
-        assert "Plan Information" in data
-        assert f"<p><strong>Name:</strong> {plan_data.name}</p>" in data
+        assert f"<h1>{plan_data.name}</h1>" in data
+        assert f"<p><strong>Name:</strong> {plan_data.name}</p>" not in data
         assert plan_data.summary in data
+
+        # Also make sure fmf_id.name is not displayed
+        assert f"<p><strong>Name:</strong> {plan_data.fmf_id.name}</p>" not in data
 
     def test_generate_status_callback_pending(self, logger):
         """Test status callback page for pending task."""


### PR DESCRIPTION
### **User description**
![](https://i.kym-cdn.com/photos/images/original/000/757/498/89c.gif)


___

### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Changed default output format to `html` in API.

- Updated tests to align with the new default format and added coverage for error handling.

- Improved HTML templates by removing redundant metadata display.

- Upgraded dependencies in `.pre-commit-config.yaml`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>api.py</strong><dd><code>Set `html` as the default output format.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/martinhoyer/web/pull/4/files#diff-c40feb84926a506e95895589630fd7744fbdc5e2c1519308f8d6fb2d2cd9efca">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>testandplan.html.j2</strong><dd><code>Removed redundant metadata display in test and plan templates.</code></dd></td>
  <td><a href="https://github.com/martinhoyer/web/pull/4/files#diff-755c6ba0117a95609638d81b593484a8661fbcbeac119b3f3348812a20461a85">+4/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>testorplan.html.j2</strong><dd><code>Simplified metadata display in test or plan templates.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/martinhoyer/web/pull/4/files#diff-37acfec67d5e839cb532b74f67bf7ce2bdf82f92965f2de00ef406a5ae3799cb">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>test_api.py</strong><dd><code>Updated integration tests for `html` default format.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/martinhoyer/web/pull/4/files#diff-50b3f8c533e7cb34f4e715b04efceb282d7482173c658b361d07c2645e7ea9db">+233/-58</a></td>

</tr>

<tr>
  <td><strong>test_converters.py</strong><dd><code>Added unit test for `_convert_fmf_id` function.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/martinhoyer/web/pull/4/files#diff-e16f1c1845de6cebb9d1dc309a1a64aad468bf6c5b45a2bef47ce042d28b56fd">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_formatters.py</strong><dd><code>Added unit tests for data serialization and deserialization.</code></dd></td>
  <td><a href="https://github.com/martinhoyer/web/pull/4/files#diff-9dab8317df76c4c49934fbb5d9dca2866c22d91bfda22ce90689e782683334c2">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_html_generator.py</strong><dd><code>Updated HTML generator tests to reflect metadata changes.</code></dd></td>
  <td><a href="https://github.com/martinhoyer/web/pull/4/files#diff-b1a4f17de78ab43afc33cb09f8fc6b6acb95df027b3753e2a1ce5ca2183e333f">+16/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_service.py</strong><dd><code>Added tests for Celery-enabled and disabled scenarios.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/martinhoyer/web/pull/4/files#diff-5b370c2e518e2100613163ab55ddc5887cc01d64f4c3122afec16ad11f64ebe1">+75/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>.pre-commit-config.yaml</strong><dd><code>Upgraded `mypy` and `ruff` versions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/martinhoyer/web/pull/4/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The API now returns an HTML response by default, offering a more user-friendly experience.
  
- **Style**
  - Web pages have been refined to dynamically display test and plan names and remove duplicate information for a cleaner presentation.

These changes enhance the clarity and consistency of the user interface and API responses, contributing to a more intuitive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->